### PR TITLE
Fix `DeprecationWarning` Exceptions when using coverage in python 2.7 with `-3`

### DIFF
--- a/coverage/cmdline.py
+++ b/coverage/cmdline.py
@@ -241,6 +241,10 @@ class CmdOptionParser(CoverageOptionParser):
         # results, and they will compare equal to objects.
         return (other == "<CmdOptionParser:%s>" % self.cmd)
 
+    # Set __hash__ to None in order to make this object unhashable in Python 2
+    # As well as Python 3.
+    __hash__ = None
+
     def get_prog_name(self):
         """Override of an undocumented function in optparse.OptionParser."""
         program_name = super(CmdOptionParser, self).get_prog_name()

--- a/coverage/plugin.py
+++ b/coverage/plugin.py
@@ -394,3 +394,6 @@ class FileReporter(object):
 
     def __ge__(self, other):
         return self.filename >= other.filename
+
+    def __hash__(self):
+        return hash(self.filename)

--- a/coverage/plugin.py
+++ b/coverage/plugin.py
@@ -395,5 +395,4 @@ class FileReporter(object):
     def __ge__(self, other):
         return self.filename >= other.filename
 
-    def __hash__(self):
-        return hash(self.filename)
+    __hash__ = None


### PR DESCRIPTION
I am investigating a migration to Python 3, and to facilitate this we are using
the `-3` flag as described here:
https://docs.python.org/3/howto/pyporting.html#prevent-compatibility-regressions . When using this flag I encountered
some issues inside of coverage itself.

Python 3 now requires you to implement `__hash__` if you implement `__eq__`. See https://docs.python.org/3.6/reference/datamodel.html#object.%5F%5Fhash%5F%5F .

{FileReporter('foo')}  # Fine in Python 2, Throws in Python 3

AFAICT FileReporter.filename isn't mutated so `__hash__` returns the hash of the filename.

If it turns out it is in fact mutated we can change this to set `__hash__` to `None` to keep the behavior the same
in Python 2 as in Python 3
